### PR TITLE
Fixed the crashes that were happening when a ray travelled forever.

### DIFF
--- a/shaders/traverse.comp
+++ b/shaders/traverse.comp
@@ -95,8 +95,9 @@ bool traversal(vec3 origin, vec3 dir, out vec3 color, inout uint steps) {
     ivec3 texel_coord = ivec3(coord.x / 4, coord.y / 4, coord.z / 8);
     uvec4 texel = imageLoad(voxelImage, texel_coord);
     bool instantHit = bool(texel[coord.x % 4] >> ((coord.y % 4) + (coord.z % 8) * 4) & 1u);
+    uint max_steps = pc.voxel_resolution * 3u;
     if (!instantHit)
-    while (true) {
+    while (steps < max_steps) {
         steps++;
 
         if (t.x < t.y) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,7 @@ mod voxelize;
 use crate::camera::Camera;
 use crate::hot_reload::HotReloadComputePipeline;
 
-const INITIAL_VOXEL_RESOLUTION: u32 = 24;
+const INITIAL_VOXEL_RESOLUTION: u32 = 128;
 const INITIAL_WINDOW_RESOLUTION: PhysicalSize<u32> = PhysicalSize::new(960, 960);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -653,7 +653,10 @@ impl App {
         rcx.gui.immediate_ui(|gui| {
             let ctx = gui.context();
 
-            egui::Window::new("Settings").show(&ctx, |ui| {
+            // Settings Window - Anchored to Top Right
+            egui::Window::new("Settings")
+                .anchor(egui::Align2::RIGHT_TOP, egui::vec2(-10.0, 10.0)) // 10px from right and top
+                .show(&ctx, |ui| {
                 ui.style_mut().spacing.slider_width = 250.0;
                 ui.horizontal(|ui| {
                     for &mode in RenderMode::ALL {
@@ -716,7 +719,9 @@ impl App {
                     );
                 }
             });
-            egui::Window::new("Stats").show(&ctx, |ui| {
+            egui::Window::new("Stats")
+                .anchor(egui::Align2::RIGHT_TOP, egui::vec2(-10.0, 260.0)) // 10px from right and bottom
+                .show(&ctx, |ui| {
                 fn format_with_commas(n: u64) -> String {
                     let mut s = n.to_string();
 


### PR DESCRIPTION
Likely due to floating point precision, a ray travelling could cause the traversal loop to go on forever. The fix is simple (just cap the loop at voxel resolution * 3, the theoretical maximum a ray could travel). This is the same fix as the one for the steps colormap.
I also did a few minor default changes; increased the voxel resolution (some models were barely understandable at the 24 voxel res), and moved the window UI to the right so it fits better with the default model.